### PR TITLE
Avoid unmarshal/marshal

### DIFF
--- a/config/json_config.go
+++ b/config/json_config.go
@@ -40,17 +40,25 @@ func (j *jsonStore) Registry() Registry {
 	return j.reg
 }
 
+type cfgData struct {
+	b []byte
+}
+
+func (d *cfgData) UnmarshalJSON(b []byte) error {
+	d.b = b
+	return nil
+}
+
 func (j *jsonStore) processData(data []byte) error {
-	jsonData := map[string]map[string]interface{}{}
+	jsonData := map[string]*cfgData{}
 	if e := json.Unmarshal(data, &jsonData); e != nil {
 		return e
 	}
 	for k, v := range jsonData {
 		t := j.reg.Get(k)
 		if t != nil {
-			b, _ := json.Marshal(v)
 			val := reflect.New(t).Interface()
-			if e := json.Unmarshal(b, val); e != nil {
+			if e := json.Unmarshal(v.b, val); e != nil {
 				return e
 			}
 			j.kv[k] = val


### PR DESCRIPTION
Add test case to cover the bad json decoding errors

@palafrank's comment got me thinking. So I decided to avoid the re-marshal. Instead I wrote a custom unmarshaler for and modeled the key:data as an internal data structure. I then used it to capture the data as []byte against a specific key and when the key is present in the registry I decode the []byte as the specific registered type. Now we are still doing two-pass parsing here but we are avoiding a re-marshal step. This will also be efficient approach if we decided to use stream decoding later.