### PR TITLE
Add CLI service to allow services to use FlagSet

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,21 @@
+package cli
+
+import (
+	"flag"
+	"os"
+
+	"github.com/anuvu/cube/service"
+)
+
+// NewCli is the CLI service constructor
+func NewCli(ctx service.Context) *flag.FlagSet {
+	flagSet := flag.NewFlagSet("cube", flag.ExitOnError)
+
+	ctx.AddLifecycle(&service.Lifecycle{
+		ConfigHook: func() {
+			flagSet.Parse(os.Args[1:])
+		},
+	})
+
+	return flagSet
+}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"flag"
+
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/anuvu/cube/service"
+)
+
+func TestCli(t *testing.T) {
+	oldArgs := os.Args
+	os.Args = []string{"cli_test", "-foo", "bar"}
+
+	Convey("After we add the CLI service, then invoke a function that requires a flagset", t, func() {
+		grp := service.NewGroup("cli", nil)
+		grp.AddService(NewCli, nil)
+		grp.Invoke(func(fs *flag.FlagSet) {
+			Convey("we should be able to add a flag to the flagset and parse it in Configure", func() {
+				So(fs, ShouldNotBeNil)
+				fs.String("foo", "baz", "usage")
+				grp.Configure()
+				So(fs.Parsed(), ShouldBeTrue)
+				fooFlag := fs.Lookup("foo")
+				So(fooFlag.Value.String(), ShouldEqual, "bar")
+			})
+		})
+	})
+	os.Args = oldArgs
+}


### PR DESCRIPTION
New service CLI produces FlagSet, to allow services to add flags.

Services using the FlagSet should add flags in their constructor.
The CLI service calls Parse() on the FlagSet once, in the Config phase.

For example, a service that requires a FlagSet should have a constructor that looks like this:

```go
func NewMyService(ctx service.Context, fs *flags.FlagSet){
    fs.Int("foo", 0, "foo usage")

    ctx.AddLifeCycle(&service.Lifecycle{
       StartHook: func(fs *flags.FlagSet){
        // Access flag value here using fs.
       }
}
```


Signed-off-by: Michael McCracken <mikmccra@cisco.com>