### PR TITLE
Simplify the service lifecycle

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,18 +4,21 @@ import (
 	"flag"
 	"os"
 
+	"github.com/anuvu/cube/config"
 	"github.com/anuvu/cube/service"
 )
 
-// NewCli is the CLI service constructor
-func NewCli(ctx service.Context) *flag.FlagSet {
-	flagSet := flag.NewFlagSet("cube", flag.ExitOnError)
+// Cli wraps flags.
+type Cli struct {
+	Flags *flag.FlagSet
+}
 
-	ctx.AddLifecycle(&service.Lifecycle{
-		ConfigHook: func() {
-			flagSet.Parse(os.Args[1:])
-		},
-	})
+// New returns new instance of Cli.
+func New() *Cli {
+	return &Cli{flag.NewFlagSet(os.Args[0], flag.ExitOnError)}
+}
 
-	return flagSet
+// Configure parses the flags.
+func (c *Cli) Configure(ctx service.Context, store config.Store) error {
+	return c.Flags.Parse(os.Args[1:])
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,15 +1,21 @@
 package cli
 
 import (
-	"flag"
-
 	"os"
+	"strings"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
 
+	"github.com/anuvu/cube/config"
 	"github.com/anuvu/cube/service"
 )
+
+func newConfigStore() config.Store {
+	r := strings.NewReader(`{"http": {"port": 8080}}
+		{"logger": {"file": "/var/log/test.log"}}`)
+	return config.NewJSONStore(r)
+}
 
 func TestCli(t *testing.T) {
 	oldArgs := os.Args
@@ -17,16 +23,15 @@ func TestCli(t *testing.T) {
 
 	Convey("After we add the CLI service, then invoke a function that requires a flagset", t, func() {
 		grp := service.NewGroup("cli", nil)
-		grp.AddService(NewCli, nil)
-		grp.Invoke(func(fs *flag.FlagSet) {
-			Convey("we should be able to add a flag to the flagset and parse it in Configure", func() {
-				So(fs, ShouldNotBeNil)
-				fs.String("foo", "baz", "usage")
-				grp.Configure()
-				So(fs.Parsed(), ShouldBeTrue)
-				fooFlag := fs.Lookup("foo")
-				So(fooFlag.Value.String(), ShouldEqual, "bar")
-			})
+		grp.AddService(newConfigStore)
+		So(grp.AddService(New), ShouldBeNil)
+		grp.Invoke(func(fs *Cli) {
+			So(fs, ShouldNotBeNil)
+			fs.Flags.String("foo", "baz", "usage")
+			So(grp.Configure(), ShouldBeNil)
+			So(fs.Flags.Parsed(), ShouldBeTrue)
+			fooFlag := fs.Flags.Lookup("foo")
+			So(fooFlag.Value.String(), ShouldEqual, "bar")
 		})
 	})
 	os.Args = oldArgs

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,12 @@
 hash: 36e55a4f0d99512271f5ca9710d6cfc005909f0f615713c6156ba694c8a9a56a
-updated: 2017-11-17T16:24:04.40354-08:00
+updated: 2017-11-17T16:46:59.878587-08:00
 imports:
 - name: github.com/anuvu/zlog
   version: ff66b04dc983fbecb5f3e0dc7d80e74c69984035
+- name: github.com/rs/zerolog
+  version: 9d194eb6f50e8718a6d6f8f1e1f0bf3ddf4065f1
+  subpackages:
+  - internal/json
 testImports:
 - name: github.com/gopherjs/gopherjs
   version: a0a7cfed7b2a54080888fd2b3d4a3ec14562c86c

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,6 @@
-hash: 7f145ad124cba2dac7c5374955fb0c202902d4c8004bab65831c0aad29cc39f5
-updated: 2017-11-15T13:33:40.000654-08:00
+hash: 36e55a4f0d99512271f5ca9710d6cfc005909f0f615713c6156ba694c8a9a56a
+updated: 2017-11-17T16:24:04.40354-08:00
 imports:
-- name: github.com/anuvu/dig
-  version: 97f1ec340a2c051e192a1a05edb3629dfc2e7542
 - name: github.com/anuvu/zlog
   version: ff66b04dc983fbecb5f3e0dc7d80e74c69984035
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,5 @@
 package: github.com/anuvu/cube
 import:
 - package: github.com/anuvu/zlog
-- package: github.com/anuvu/dig
 testImport:
 - package: github.com/smartystreets/goconvey/convey

--- a/http/server.go
+++ b/http/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/anuvu/cube/config"
 	"github.com/anuvu/cube/service"
@@ -15,64 +16,54 @@ type Service interface {
 }
 
 type server struct {
-	port int
-	mux  *http.ServeMux
-	server http.Server
-	running bool
+	config  *Config
+	mux     *http.ServeMux
+	server  http.Server
+	running int32
 }
 
-// NewService creates a new HTTP Service
-func NewService(ctx service.Context) Service {
-	s := &server{mux: http.NewServeMux()}
-	ctx.AddLifecycle(s.getLifecycle())
-	return s
+// Config defines the configurable parameters of http service
+type Config struct {
+	// Listen port
+	Port int `json:"port"`
+}
+
+// New creates a new HTTP Service
+func New(ctx service.Context) Service {
+	return &server{config: &Config{}, mux: http.NewServeMux()}
 }
 
 func (s *server) Register(url string, h http.Handler) {
 	s.mux.Handle(url, h)
 }
 
-func (s *server) getLifecycle() *service.Lifecycle {
-	return &service.Lifecycle {
-		ConfigHook: s.ConfigHook,
-		StartHook: s.StartHook,
-		StopHook: s.StopHook,
-		HealthHook: s.HealthHook,
-	}
-}
-
-func (s *server) ConfigHook(store config.Store) error {
-	if err := store.Get("httpPort", &s.port); err != nil {
+func (s *server) Configure(ctx service.Context, store config.Store) error {
+	if err := store.Get("http", s.config); err != nil {
 		return err
 	}
-
 	return nil
 }
 
-func (s *server) StartHook() error {
-	s.server = http.Server{Addr: fmt.Sprintf("localhost:%d", s.port), Handler: s.mux}
-	started := make(chan bool)
+func (s *server) Start(ctx service.Context) error {
+	s.server = http.Server{Addr: fmt.Sprintf("localhost:%d", s.config.Port), Handler: s.mux}
+	l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", s.config.Port))
+	if err != nil {
+		return err
+	}
 	go func() {
-		l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", s.port))
-		started <- true
-		if err != nil {
-			fmt.Println("failed to listen\n");
-			return
-		}
-		s.running = true
+		atomic.AddInt32(&s.running, 1)
 		if err := s.server.Serve(l); err != nil {
-			fmt.Println("serve failed %v", err)
+			fmt.Printf("serve stopping: %v\n", err)
 		}
-		s.running = false
 	}()
-	<-started
 	return nil
 }
 
-func (s *server) StopHook() error {
+func (s *server) Stop(ctx service.Context) error {
+	atomic.AddInt32(&s.running, -1)
 	return s.server.Close()
 }
 
-func (s *server) HealthHook() bool {
-	return s.running
+func (s *server) IsHealthy(ctx service.Context) bool {
+	return atomic.LoadInt32(&s.running) > 0
 }

--- a/service/container.go
+++ b/service/container.go
@@ -6,11 +6,27 @@ import (
 	"reflect"
 )
 
+// Container provides dependency injection for services. Each container keeps
+// track of an object table that maps a type to its instantiation. As a new
+// service constructor is added, the container checks its parameters and
+// marks them as dependencies and caches the return value in the object table.
+// Each dependency is evaluated as soon as the constructor is added to the
+// container.
+//
+// Containers are chained with parent first delegation model. This means that
+// when ever a dependency is evaluated, the container checks if its parent
+// container provides the object first before checking its own object table.
+//
+// By adding the services in their order of dependency into a container and
+// by chaining these containers we can build the complete static dependency
+// graph of a process.
 type container struct {
 	parent   *container
 	objTable map[reflect.Type]reflect.Value
 }
 
+// newContainer creates a new container with a parent container, if parent
+// is nil it is a root container.
 func newContainer(p *container) *container {
 	return &container{
 		parent:   p,
@@ -18,7 +34,13 @@ func newContainer(p *container) *container {
 	}
 }
 
-func (c *container) invokeAndProcess(ctr interface{}, resFunc func([]reflect.Value) error) error {
+// resultProcessor is a function handler that can process the
+// results produced by a constructor.
+type resultProcessor func([]reflect.Value) error
+
+// invokeAndProcess invokes a provided constructor by resolving its dependencies
+// and calls the result processor on the results if the constructor succeeds.
+func (c *container) invokeAndProcess(ctr interface{}, resFunc resultProcessor) error {
 	// Check for function type
 	f := reflect.TypeOf(ctr)
 	if e := checkFunc(ctr, f); e != nil {
@@ -34,17 +56,31 @@ func (c *container) invokeAndProcess(ctr interface{}, resFunc func([]reflect.Val
 	// Call the function
 	returned := reflect.ValueOf(ctr).Call(args)
 
-	// process results
-	return resFunc(returned)
+	// Check for errors
+	if err := checkError(returned); err != nil {
+		return err
+	}
+
+	// Process results if a processor is provided
+	if resFunc != nil {
+		return resFunc(returned)
+	}
+	return nil
 }
 
+// invoke call the constructor provided.
 func (c *container) invoke(ctr interface{}) error {
-	return c.invokeAndProcess(ctr, func(returned []reflect.Value) error {
-		return checkError(returned)
-	})
+	return c.invokeAndProcess(ctr, nil)
 }
 
-func (c *container) addWithProcessValue(ctr interface{}, vf func(v reflect.Value)) error {
+// value processor is handler that can process each value produced
+// while adding a service constructor. Handlers can be used to cache
+// object instances externally for lifecycle invocations.
+type valueProcessor func(reflect.Value)
+
+// add invokes the constructor and calls the value processor on each
+// object the constructor produced.
+func (c *container) add(ctr interface{}, vf valueProcessor) error {
 	return c.invokeAndProcess(ctr, func(returned []reflect.Value) error {
 		if e := checkError(returned); e != nil {
 			return e
@@ -63,10 +99,8 @@ func (c *container) addWithProcessValue(ctr interface{}, vf func(v reflect.Value
 	})
 }
 
-func (c *container) add(ctr interface{}) error {
-	return c.addWithProcessValue(ctr, nil)
-}
-
+// buildArgs builds the arguments required by the constructor by looking
+// up the object table.
 func (c *container) buildArgs(ctrType reflect.Type) ([]reflect.Value, error) {
 	numArgs := ctrType.NumIn()
 	if ctrType.IsVariadic() {
@@ -84,6 +118,9 @@ func (c *container) buildArgs(ctrType reflect.Type) ([]reflect.Value, error) {
 	return vals, nil
 }
 
+// get finds a object required by buildArgs. It looks up the parent
+// container first for the object and then the object table of this
+// container.
 func (c *container) get(in reflect.Type) (reflect.Value, error) {
 	// Always find the value in the parent type first.
 	if c.parent != nil {
@@ -110,6 +147,10 @@ func (c *container) get(in reflect.Type) (reflect.Value, error) {
 	return v, nil
 }
 
+// put caches the object produced in the object table of the container.
+// If the object is already present in the object table, the value is
+// rejected. This makes sure that there is only one constructor that
+// can produce and object of a specific type in a given container hierarchy.
 func (c *container) put(v reflect.Value) error {
 	t := v.Type()
 	if t.Kind() == reflect.Ptr {
@@ -126,6 +167,8 @@ var (
 	_errType = reflect.TypeOf((*error)(nil)).Elem()
 )
 
+// checkError checks if the value list ends with an error type and returns
+// that error. this is used to see if a constructor produced an error.
 func checkError(returned []reflect.Value) error {
 	if len(returned) == 0 {
 		return nil
@@ -138,6 +181,7 @@ func checkError(returned []reflect.Value) error {
 	return nil
 }
 
+// checkFunc checks if a constructor is a valid function that can be invoked.
 func checkFunc(ctr interface{}, f reflect.Type) error {
 	if f == nil {
 		return errors.New("can't invoke an untyped nil")

--- a/service/container.go
+++ b/service/container.go
@@ -1,0 +1,149 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+type container struct {
+	parent   *container
+	objTable map[reflect.Type]reflect.Value
+}
+
+func newContainer(p *container) *container {
+	return &container{
+		parent:   p,
+		objTable: map[reflect.Type]reflect.Value{},
+	}
+}
+
+func (c *container) invokeAndProcess(ctr interface{}, resFunc func([]reflect.Value) error) error {
+	// Check for function type
+	f := reflect.TypeOf(ctr)
+	if e := checkFunc(ctr, f); e != nil {
+		return e
+	}
+
+	// Build the arguments list
+	args, err := c.buildArgs(f)
+	if err != nil {
+		return err
+	}
+
+	// Call the function
+	returned := reflect.ValueOf(ctr).Call(args)
+
+	// process results
+	return resFunc(returned)
+}
+
+func (c *container) invoke(ctr interface{}) error {
+	return c.invokeAndProcess(ctr, func(returned []reflect.Value) error {
+		return checkError(returned)
+	})
+}
+
+func (c *container) addWithProcessValue(ctr interface{}, vf func(v reflect.Value)) error {
+	return c.invokeAndProcess(ctr, func(returned []reflect.Value) error {
+		if e := checkError(returned); e != nil {
+			return e
+		}
+
+		for _, v := range returned {
+			if e := c.put(v); e != nil {
+				return e
+			}
+			if vf != nil {
+				// Call the value processor
+				vf(v)
+			}
+		}
+		return nil
+	})
+}
+
+func (c *container) add(ctr interface{}) error {
+	return c.addWithProcessValue(ctr, nil)
+}
+
+func (c *container) buildArgs(ctrType reflect.Type) ([]reflect.Value, error) {
+	numArgs := ctrType.NumIn()
+	if ctrType.IsVariadic() {
+		// Ignore the variadic argument
+		numArgs--
+	}
+	vals := make([]reflect.Value, 0, numArgs)
+	for i := 0; i < numArgs; i++ {
+		v, err := c.get(ctrType.In(i))
+		if err != nil {
+			return nil, err
+		}
+		vals = append(vals, v)
+	}
+	return vals, nil
+}
+
+func (c *container) get(in reflect.Type) (reflect.Value, error) {
+	// Always find the value in the parent type first.
+	if c.parent != nil {
+		v, err := c.parent.get(in)
+
+		// We found the value in our ancestry, so return that value.
+		if err == nil {
+			return v, err
+		}
+	}
+
+	// Check in this container for the value
+	inType := in
+	if in.Kind() == reflect.Ptr {
+		inType = in.Elem()
+	}
+	v, ok := c.objTable[inType]
+
+	if !ok {
+		return v, fmt.Errorf("dependency for type %v not found", in)
+	}
+
+	// Found Value!
+	return v, nil
+}
+
+func (c *container) put(v reflect.Value) error {
+	t := v.Type()
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if _, err := c.get(t); err == nil {
+		return fmt.Errorf("type %v is already present", v.Type())
+	}
+	c.objTable[t] = v
+	return nil
+}
+
+var (
+	_errType = reflect.TypeOf((*error)(nil)).Elem()
+)
+
+func checkError(returned []reflect.Value) error {
+	if len(returned) == 0 {
+		return nil
+	}
+	if last := returned[len(returned)-1]; last.Type().Implements(_errType) {
+		if err, _ := last.Interface().(error); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkFunc(ctr interface{}, f reflect.Type) error {
+	if f == nil {
+		return errors.New("can't invoke an untyped nil")
+	}
+	if f.Kind() != reflect.Func {
+		return fmt.Errorf("can't invoke non-function %v (type %v)", ctr, f)
+	}
+	return nil
+}

--- a/service/container_test.go
+++ b/service/container_test.go
@@ -18,25 +18,25 @@ func TestContainer(t *testing.T) {
 	Convey("Create a container", t, func() {
 		c := newContainer(nil)
 		Convey("cannot add non-func or nil", func() {
-			So(c.add(10), ShouldNotBeNil)
-			So(c.add(nil), ShouldNotBeNil)
+			So(c.add(10, nil), ShouldNotBeNil)
+			So(c.add(nil, nil), ShouldNotBeNil)
 		})
 		Convey("cannot add a func in case of error", func() {
-			So(c.add(func() (*testS1, error) { return nil, errors.New("test error") }), ShouldNotBeNil)
+			So(c.add(func() (*testS1, error) { return nil, errors.New("test error") }, nil), ShouldNotBeNil)
 		})
 		Convey("should accept a variadic constructor but ignore the variadic list", func() {
-			So(c.add(func(b ...int) {}), ShouldBeNil)
+			So(c.add(func(b ...int) {}, nil), ShouldBeNil)
 		})
 		Convey("can add a constructor", func() {
-			So(c.add(func() *testS1 { return &testS1{} }), ShouldBeNil)
+			So(c.add(func() *testS1 { return &testS1{} }, nil), ShouldBeNil)
 			So(c.invoke(func(t *testS1) {}), ShouldBeNil)
-			So(c.add(func() *testS1 { return &testS1{} }), ShouldNotBeNil)
+			So(c.add(func() *testS1 { return &testS1{} }, nil), ShouldNotBeNil)
 		})
 		Convey("cannot add constructor with bad dependencies", func() {
-			So(c.add(func(c *container) *container { return nil }), ShouldNotBeNil)
+			So(c.add(func(c *container) *container { return nil }, nil), ShouldNotBeNil)
 		})
 		Convey("add with a value processor", func() {
-			e := c.addWithProcessValue(
+			e := c.add(
 				func() *testS1 { return &testS1{} },
 				func(v reflect.Value) {
 					So(v.Interface(), ShouldNotBeNil)
@@ -46,8 +46,8 @@ func TestContainer(t *testing.T) {
 		Convey("can create a hierarchy", func() {
 			cc := newContainer(c)
 			So(cc, ShouldNotBeNil)
-			c.add(func() *testS1 { return &testS1{} })
-			So(cc.add(func(s1 *testS1) *testS2 { return &testS2{} }), ShouldBeNil)
+			c.add(func() *testS1 { return &testS1{} }, nil)
+			So(cc.add(func(s1 *testS1) *testS2 { return &testS2{} }, nil), ShouldBeNil)
 			So(cc.invoke(func(s2 *testS2) {}), ShouldBeNil)
 		})
 	})

--- a/service/container_test.go
+++ b/service/container_test.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type testS1 struct {
+}
+
+type testS2 struct {
+}
+
+func TestContainer(t *testing.T) {
+	Convey("Create a container", t, func() {
+		c := newContainer(nil)
+		Convey("cannot add non-func or nil", func() {
+			So(c.add(10), ShouldNotBeNil)
+			So(c.add(nil), ShouldNotBeNil)
+		})
+		Convey("cannot add a func in case of error", func() {
+			So(c.add(func() (*testS1, error) { return nil, errors.New("test error") }), ShouldNotBeNil)
+		})
+		Convey("should accept a variadic constructor but ignore the variadic list", func() {
+			So(c.add(func(b ...int) {}), ShouldBeNil)
+		})
+		Convey("can add a constructor", func() {
+			So(c.add(func() *testS1 { return &testS1{} }), ShouldBeNil)
+			So(c.invoke(func(t *testS1) {}), ShouldBeNil)
+			So(c.add(func() *testS1 { return &testS1{} }), ShouldNotBeNil)
+		})
+		Convey("cannot add constructor with bad dependencies", func() {
+			So(c.add(func(c *container) *container { return nil }), ShouldNotBeNil)
+		})
+		Convey("add with a value processor", func() {
+			e := c.addWithProcessValue(
+				func() *testS1 { return &testS1{} },
+				func(v reflect.Value) {
+					So(v.Interface(), ShouldNotBeNil)
+				})
+			So(e, ShouldBeNil)
+		})
+		Convey("can create a hierarchy", func() {
+			cc := newContainer(c)
+			So(cc, ShouldNotBeNil)
+			c.add(func() *testS1 { return &testS1{} })
+			So(cc.add(func(s1 *testS1) *testS2 { return &testS2{} }), ShouldBeNil)
+			So(cc.invoke(func(s2 *testS2) {}), ShouldBeNil)
+		})
+	})
+}

--- a/service/ctx.go
+++ b/service/ctx.go
@@ -4,21 +4,6 @@ import (
 	"context"
 )
 
-// Lifecycle captures the service lifecycle hooks.
-type Lifecycle struct {
-	// Service configure hook, must be a function
-	ConfigHook interface{}
-
-	// Service Start hook, must be a function
-	StartHook interface{}
-
-	// Service Stop hook, must be a function
-	StopHook interface{}
-
-	// Service health hook
-	HealthHook func() bool
-}
-
 // Context provides a wrapper interface for go context.
 //
 // Ctx() returns the underlying go context.
@@ -29,7 +14,6 @@ type Lifecycle struct {
 type Context interface {
 	Ctx() context.Context
 	Shutdown()
-	AddLifecycle(*Lifecycle)
 }
 
 // NewContext creates a new service context.
@@ -43,14 +27,12 @@ func newContext() *srvCtx {
 	return &srvCtx{
 		ctx:        ctx,
 		cancelFunc: cancelFunc,
-		hooks:      []*Lifecycle{},
 	}
 }
 
 type srvCtx struct {
 	ctx        context.Context
 	cancelFunc context.CancelFunc
-	hooks      []*Lifecycle
 }
 
 func (sc *srvCtx) Ctx() context.Context {
@@ -59,8 +41,4 @@ func (sc *srvCtx) Ctx() context.Context {
 
 func (sc *srvCtx) Shutdown() {
 	sc.cancelFunc()
-}
-
-func (sc *srvCtx) AddLifecycle(lc *Lifecycle) {
-	sc.hooks = append(sc.hooks, lc)
 }

--- a/service/ctx.go
+++ b/service/ctx.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+
+	"github.com/anuvu/zlog"
 )
 
 // Context provides a wrapper interface for go context.
@@ -14,6 +16,7 @@ import (
 type Context interface {
 	Ctx() context.Context
 	Shutdown()
+	Log() zlog.Logger
 }
 
 // NewContext creates a new service context.
@@ -27,12 +30,14 @@ func newContext() *srvCtx {
 	return &srvCtx{
 		ctx:        ctx,
 		cancelFunc: cancelFunc,
+		log:        zlog.New("cube"),
 	}
 }
 
 type srvCtx struct {
 	ctx        context.Context
 	cancelFunc context.CancelFunc
+	log        zlog.Logger
 }
 
 func (sc *srvCtx) Ctx() context.Context {
@@ -41,4 +46,8 @@ func (sc *srvCtx) Ctx() context.Context {
 
 func (sc *srvCtx) Shutdown() {
 	sc.cancelFunc()
+}
+
+func (sc *srvCtx) Log() zlog.Logger {
+	return sc.log
 }

--- a/service/ctx_test.go
+++ b/service/ctx_test.go
@@ -1,0 +1,20 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestContext(t *testing.T) {
+	Convey("After we create a context", t, func() {
+		ctx := NewContext()
+		go func() {
+			<-ctx.Ctx().Done()
+			ctx.Log().Info().Msg("Done")
+		}()
+		time.Sleep(time.Second)
+		ctx.Shutdown()
+	})
+}

--- a/service/group.go
+++ b/service/group.go
@@ -1,14 +1,41 @@
 package service
 
-import "reflect"
+import (
+	"reflect"
+
+	"github.com/anuvu/cube/config"
+)
+
+// ConfigHook is the interface that provides the configuration call back for the service.
+type ConfigHook interface {
+	Configure(ctx Context, store config.Store) error
+}
+
+// StartHook is the interface that provides the start call back for the service.
+type StartHook interface {
+	Start(ctx Context) error
+}
+
+// StopHook is the interface that provides the stop call back for the service.
+type StopHook interface {
+	Stop(ctx Context) error
+}
+
+// HealthHook is the interface that provides the health call back for the service.
+type HealthHook interface {
+	IsHealthy(ctx Context) bool
+}
 
 // Group is a group of services, that have inter-dependencies.
 type Group struct {
-	name     string
-	parent   *Group
-	c        *container
-	ctx      *srvCtx
-	invokers []interface{}
+	name        string
+	parent      *Group
+	c           *container
+	ctx         *srvCtx
+	configHooks []ConfigHook
+	startHooks  []StartHook
+	stopHooks   []StopHook
+	healthHooks []HealthHook
 }
 
 // NewGroup creates a new service group with the specified parent. If the parent is nil
@@ -24,11 +51,14 @@ func NewGroup(name string, parent *Group) *Group {
 		ctx = parent.ctx
 	}
 	grp := &Group{
-		name:     name,
-		parent:   parent,
-		c:        c,
-		ctx:      ctx,
-		invokers: []interface{}{},
+		name:        name,
+		parent:      parent,
+		c:           c,
+		ctx:         ctx,
+		configHooks: []ConfigHook{},
+		startHooks:  []StartHook{},
+		stopHooks:   []StopHook{},
+		healthHooks: []HealthHook{},
 	}
 
 	// Provide the context if we are the root group
@@ -43,7 +73,19 @@ func NewGroup(name string, parent *Group) *Group {
 // AddService adds a new service constructor to the service group.
 func (g *Group) AddService(ctr interface{}) error {
 	vf := func(v reflect.Value) {
-
+		val := v.Interface()
+		if i, ok := val.(ConfigHook); ok {
+			g.configHooks = append(g.configHooks, i)
+		}
+		if i, ok := val.(StartHook); ok {
+			g.startHooks = append(g.startHooks, i)
+		}
+		if i, ok := val.(StopHook); ok {
+			g.stopHooks = append(g.stopHooks, i)
+		}
+		if i, ok := val.(HealthHook); ok {
+			g.healthHooks = append(g.healthHooks, i)
+		}
 	}
 	// add the service constructor to the container
 	return g.c.addWithProcessValue(ctr, vf)
@@ -56,11 +98,9 @@ func (g *Group) Invoke(f interface{}) error {
 
 // Configure calls the configure hooks on all services registered for configuration.
 func (g *Group) Configure() error {
-	for _, h := range g.ctx.hooks {
-		if h.ConfigHook != nil {
-			if err := g.c.invoke(h.ConfigHook); err != nil {
-				return err
-			}
+	for _, h := range g.configHooks {
+		if err := g.c.invoke(h.Configure); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -70,12 +110,13 @@ func (g *Group) Configure() error {
 // If an error occurs on any hook, subsequent start calls are abandoned
 // and a best effort stop is initiated.
 func (g *Group) Start() error {
-	for i, h := range g.ctx.hooks {
-		if h.StartHook != nil {
-			if err := g.c.invoke(h.StartHook); err != nil {
-				defer g.stop(i + 1)
-				return err
-			}
+	for _, h := range g.startHooks {
+		if err := g.c.invoke(h.Start); err != nil {
+			// We need to call all stop hooks and ignore errors
+			// as we dont know which services are actually participating
+			// in the stop callbacks
+			defer g.Stop()
+			return err
 		}
 	}
 	return nil
@@ -83,27 +124,21 @@ func (g *Group) Start() error {
 
 // Stop calls the stop hooks on all services registered for shutdown.
 func (g *Group) Stop() error {
+	var e error
 	// Invoke the stop hooks in the reverse dependency order
-	return g.stop(len(g.ctx.hooks))
-}
-
-func (g *Group) stop(index int) error {
-	for i := index; i > 0; {
-		i--
-		h := g.ctx.hooks[i]
-		if h.StopHook != nil {
-			if err := g.c.invoke(h.StopHook); err != nil {
-				return err
-			}
+	for _, h := range g.stopHooks {
+		if err := g.c.invoke(h.Stop); err != nil {
+			// FIXME: We need to make this multi-error
+			e = err
 		}
 	}
-	return nil
+	return e
 }
 
 // IsHealthy returns true if all services health hooks return true else false
 func (g *Group) IsHealthy() bool {
-	for _, h := range g.ctx.hooks {
-		if h.HealthHook != nil && !h.HealthHook() {
+	for _, h := range g.healthHooks {
+		if !h.IsHealthy(g.ctx) {
 			return false
 		}
 	}

--- a/service/group.go
+++ b/service/group.go
@@ -65,7 +65,7 @@ func NewGroup(name string, parent *Group) *Group {
 	if grp.parent == nil {
 		grp.c.add(func() Context {
 			return grp.ctx
-		})
+		}, nil)
 	}
 	return grp
 }
@@ -88,7 +88,7 @@ func (g *Group) AddService(ctr interface{}) error {
 		}
 	}
 	// add the service constructor to the container
-	return g.c.addWithProcessValue(ctr, vf)
+	return g.c.add(ctr, vf)
 }
 
 // Invoke invokes a function with dependency injection.

--- a/service/group.go
+++ b/service/group.go
@@ -43,23 +43,16 @@ func NewGroup(name string, parent *Group) *Group {
 }
 
 // AddService adds a new service constructor to the service group.
-func (g *Group) AddService(ctr interface{}, invoker interface{}) error {
-	if invoker != nil {
-		g.invokers = append(g.invokers, invoker)
-	}
+func (g *Group) AddService(ctr interface{}) error {
 	// add the service constructor to the container
-	return g.container.Provide(ctr)
-}
-
-// Create creates the leaf level services, that bootstraps the service group
-func (g *Group) Create() error {
-	for _, inv := range g.invokers {
-		if err := g.container.Invoke(inv); err != nil {
-			return err
-		}
+	if e := g.container.Provide(ctr); e != nil {
+		return e
 	}
 
-	return nil
+	// Invoke the constructor to force the object creation,
+	// this makes sure that all dependent objects are already
+	// added to this group or the ancestor group.
+	return g.container.Invoke(ctr)
 }
 
 // Invoke invokes a function with dependency injection.

--- a/service/group_test.go
+++ b/service/group_test.go
@@ -56,7 +56,7 @@ func TestGroup(t *testing.T) {
 		So(grp.ctx, ShouldNotBeNil)
 
 		Convey("we should be able to add a service with no hooks", func() {
-			So(grp.AddService(func(ctx Context) *svc { return &svc{} }, nil), ShouldBeNil)
+			So(grp.AddService(func(ctx Context) *svc { return &svc{} }), ShouldBeNil)
 			So(grp.Configure(), ShouldBeNil)
 			So(grp.Start(), ShouldBeNil)
 			So(grp.Stop(), ShouldBeNil)
@@ -70,9 +70,8 @@ func TestGroup(t *testing.T) {
 		})
 
 		Convey("we should be able to add service with hooks", func() {
-			err := grp.AddService(newSvcWithHooks, func(x *svcWithHooks) {})
+			err := grp.AddService(newSvcWithHooks)
 			So(err, ShouldBeNil)
-			So(grp.Create(), ShouldBeNil)
 			So(grp.IsHealthy(), ShouldBeFalse)
 
 			grp.Invoke(func(s *svcWithHooks) {
@@ -84,7 +83,7 @@ func TestGroup(t *testing.T) {
 				Convey("we should be able to start the group", func() {
 					So(grp.Start(), ShouldBeNil)
 					So(s.startCalled, ShouldBeTrue)
-					So(grp.IsHealthy(), ShouldBeTrue)
+					//So(grp.IsHealthy(), ShouldBeTrue)
 				})
 				Convey("we should be able to stop the group", func() {
 					So(grp.Stop(), ShouldBeNil)
@@ -95,8 +94,7 @@ func TestGroup(t *testing.T) {
 		})
 
 		Convey("check service with errors", func() {
-			So(grp.AddService(newSvcWithErrors, func(x *svcWithErrors) {}), ShouldBeNil)
-			So(grp.Create(), ShouldBeNil)
+			So(grp.AddService(newSvcWithErrors), ShouldBeNil)
 			So(grp.IsHealthy(), ShouldBeFalse)
 			grp.Invoke(func(s *svcWithErrors) {
 				Convey("configure the group should be error", func() {
@@ -128,8 +126,7 @@ func TestGroupHierarchy(t *testing.T) {
 			grp := NewGroup("test", root)
 			So(grp, ShouldNotBeNil)
 			Convey("we should be able to add service with hooks", func() {
-				So(grp.AddService(newSvcWithHooks, func(x *svcWithHooks) {}), ShouldBeNil)
-				So(grp.Create(), ShouldBeNil)
+				So(grp.AddService(newSvcWithHooks), ShouldBeNil)
 				So(grp.IsHealthy(), ShouldBeFalse)
 
 				grp.Invoke(func(s *svcWithHooks) {
@@ -141,7 +138,7 @@ func TestGroupHierarchy(t *testing.T) {
 					Convey("we should be able to start the group", func() {
 						So(grp.Start(), ShouldBeNil)
 						So(s.startCalled, ShouldBeTrue)
-						So(grp.IsHealthy(), ShouldBeTrue)
+						// So(grp.IsHealthy(), ShouldBeTrue)
 					})
 					Convey("we should be able to stop the group", func() {
 						So(grp.Stop(), ShouldBeNil)

--- a/service/group_test.go
+++ b/service/group_test.go
@@ -83,7 +83,7 @@ func TestGroup(t *testing.T) {
 				Convey("we should be able to start the group", func() {
 					So(grp.Start(), ShouldBeNil)
 					So(s.startCalled, ShouldBeTrue)
-					//So(grp.IsHealthy(), ShouldBeTrue)
+					So(grp.IsHealthy(), ShouldBeTrue)
 				})
 				Convey("we should be able to stop the group", func() {
 					So(grp.Stop(), ShouldBeNil)
@@ -138,7 +138,7 @@ func TestGroupHierarchy(t *testing.T) {
 					Convey("we should be able to start the group", func() {
 						So(grp.Start(), ShouldBeNil)
 						So(s.startCalled, ShouldBeTrue)
-						// So(grp.IsHealthy(), ShouldBeTrue)
+						So(grp.IsHealthy(), ShouldBeTrue)
 					})
 					Convey("we should be able to stop the group", func() {
 						So(grp.Stop(), ShouldBeNil)


### PR DESCRIPTION
* Remove dependencies on dig which forces a specific service lifecycle
* Make service lifecycle independent interfaces so that services can just implement the hooks in-place